### PR TITLE
rewrite state again

### DIFF
--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -10,15 +10,13 @@
   "dependencies": {
     "@types/node": "^18.7.6",
     "@types/react": "^18.0.17",
-    "jotai": "^1.7.8",
     "motion": "^10.14.0",
     "next": "^12.2.5",
     "next-transpile-modules": "^9.0.0",
     "react": "*",
     "react-dom": "*",
     "reforest": "workspace:*",
-    "suspend-react": "^0.0.8",
-    "tree-visit": "^0.1.2",
-    "typescript": "^4.7.4"
+    "typescript": "^4.7.4",
+    "valtio": "^1.6.3"
   }
 }

--- a/packages/example/pages/simple.tsx
+++ b/packages/example/pages/simple.tsx
@@ -1,18 +1,11 @@
 import * as React from "react"
 import type { TreeState } from "reforest"
-import { useTree, useTreeData, useTreeState } from "reforest"
-import { atom, useAtomValue } from "jotai"
+import { useTree, useTreeData, useTreeSnapshot, useTreeState } from "reforest"
 
 function TotalDuration({ treeState }: { treeState: TreeState }) {
-  const treeNodeAtoms = React.useMemo(
-    () =>
-      atom((get) =>
-        Array.from(get(treeState.atoms.treeMapAtom).values()).map((atom) => get(atom as any))
-      ),
-    [treeState.atoms.treeMapAtom]
-  )
-  const treeNodes = useAtomValue(treeNodeAtoms)
-  const totalDuration = treeNodes.reduce((total, node: any) => total + node.duration, 0) as number
+  const totalDuration = useTreeSnapshot(treeState, (treeMap) => {
+    return Array.from(treeMap.values()).reduce((total, node: any) => total + node.duration, 0)
+  })
 
   return <div>Total Duration: {totalDuration}</div>
 }

--- a/packages/reforest/package.json
+++ b/packages/reforest/package.json
@@ -43,9 +43,10 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
-    "jotai": "^1.7.8",
     "performant-array-to-tree": "^1.11.0",
-    "suspend-react": "^0.0.8"
+    "proxy-memoize": "^1.2.0",
+    "suspend-react": "^0.0.8",
+    "valtio": "^1.6.3"
   },
   "devDependencies": {
     "@jsxui/layout": "^0.1.3",

--- a/packages/reforest/src/contexts.ts
+++ b/packages/reforest/src/contexts.ts
@@ -1,5 +1,6 @@
 import * as React from "react"
-import { Atom, PrimitiveAtom } from "jotai"
+import { ref, proxy } from "valtio"
+import { proxyMap } from "valtio/utils"
 
 import { DATA_ID, isServer } from "./utils"
 
@@ -31,18 +32,39 @@ export function getInitialComputedData() {
   return new Map(serverEntries)
 }
 
-export const ComputedDataContext = React.createContext<Map<string, any>>(getInitialComputedData())
+export const TreeComputedDataContext = React.createContext<Map<string, any>>(
+  getInitialComputedData()
+)
 
-ComputedDataContext.displayName = "ComputedDataContext"
+TreeComputedDataContext.displayName = "TreeComputedDataContext"
 
-export const TreeAtomsContext = React.createContext<{
-  computedTreeMapAtom: PrimitiveAtom<Map<string, any>>
-  treeMapAtom: PrimitiveAtom<Map<string, any>>
-  treeMapEntriesAtom: Atom<any[]>
-} | null>(null)
+export function createInitialTreeState() {
+  const initialEntries: any = []
+  const state = proxy<{
+    treeMap: Map<string, any>
+    subscribeTreeData: (key: string, value: any) => () => void
+  }>({
+    treeMap: proxyMap<string, any>(initialEntries),
+    subscribeTreeData: (key: string, value: any) => {
+      state.treeMap.set(key, ref(value))
+      return () => {
+        state.treeMap.delete(key)
+      }
+    },
+  })
 
-TreeAtomsContext.displayName = "TreeAtomsContext"
+  return state
+}
 
-export const TreeMapContext = React.createContext<Map<string, any> | null>(null)
+export type TreeStateContextValue = {
+  treeMap: Map<string, any>
+  subscribeTreeData: (key: string, value: any) => () => void
+}
+
+export const TreeStateContext = React.createContext<TreeStateContextValue | null>(null)
+
+TreeStateContext.displayName = "TreeStateContext"
+
+export const TreeMapContext = React.createContext<Map<string, any>>(new Map())
 
 TreeMapContext.displayName = "TreeMapContext"

--- a/packages/reforest/src/index.ts
+++ b/packages/reforest/src/index.ts
@@ -2,7 +2,7 @@ export { createTreeProvider, stringifyTreeMap } from "./server"
 export { useIndex, useIndexedChildren } from "./use-indexed-children"
 export { useRovingIndex } from "./use-roving-index"
 export type { TreeState } from "./use-tree"
-export { useTree, useTreeData, useTreeState } from "./use-tree"
+export { useTree, useTreeEffect, useTreeData, useTreeSnapshot, useTreeState } from "./use-tree"
 export {
   cleanAndSortTree,
   compareIndexPaths,

--- a/packages/reforest/src/server.tsx
+++ b/packages/reforest/src/server.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { suspend } from "suspend-react"
 
-import { ComputedDataContext, TreeMapContext } from "./contexts"
+import { TreeComputedDataContext, TreeMapContext } from "./contexts"
 import { isServer, sortMapByIndexPath } from "./utils"
 
 const DATA_ID = "__REFOREST_DATA__"
@@ -23,9 +23,9 @@ export function createTreeProvider(initialEntries?: [string, any][]) {
 
   function TreeProvider(props: { children: React.ReactNode }) {
     return (
-      <ComputedDataContext.Provider value={treeComputedData}>
+      <TreeComputedDataContext.Provider value={treeComputedData}>
         {props.children}
-      </ComputedDataContext.Provider>
+      </TreeComputedDataContext.Provider>
     )
   }
 
@@ -50,7 +50,7 @@ export function useServerComputedData<TreeValue extends any, ComputedTreeValue e
   computeData?: (treeMap: Map<string, TreeValue>, treeId: string) => ComputedTreeValue
 ) {
   const treeMap = React.useContext(TreeMapContext)
-  const treeComputedData = React.useContext(ComputedDataContext)
+  const treeComputedData = React.useContext(TreeComputedDataContext)
 
   /** Use Suspense to re-render the component before committing the final props on the server. */
   const isServerWithComputedData = isServer && treeMap && computeData !== undefined

--- a/packages/reforest/src/utils.ts
+++ b/packages/reforest/src/utils.ts
@@ -26,7 +26,7 @@ export function compareIndexPaths(a: string = "", b: string = "") {
   let bArray = b.split(".").map(Number)
 
   if (aArray.includes(NaN) || bArray.includes(NaN)) {
-    throw "Version contains parts that are not numbers"
+    throw new Error("Version contains parts that are not numbers")
   }
 
   const maxLength = Math.max(a.length, b.length)
@@ -35,8 +35,8 @@ export function compareIndexPaths(a: string = "", b: string = "") {
   aArray = Array.from({ ...aArray, length: maxLength }, (value) => value ?? 0)
   bArray = Array.from({ ...bArray, length: maxLength }, (value) => value ?? 0)
 
-  for (let i = 0; i < maxLength; i++) {
-    const difference = aArray[i] - bArray[i]
+  for (let index = 0; index < maxLength; index++) {
+    const difference = aArray[index] - bArray[index]
 
     if (difference === 0) {
       continue
@@ -64,7 +64,7 @@ export function cleanAndSortTree(tree: any) {
 }
 
 /** Builds an array of trees from a Map of data collected in useTree. */
-export function mapToChildren(dataMap: Map<string, any>) {
+export function mapToChildren(dataMap: Map<string, any>): Array<any> {
   const parsedValues = Array.from(dataMap.values()).map((data) => {
     const parentIndexPathString = parseIndexPath(data.indexPathString).slice(0, -1).join(".")
 
@@ -77,7 +77,7 @@ export function mapToChildren(dataMap: Map<string, any>) {
   const tree = arrayToTree(parsedValues, { dataField: null })
   const cleanedTree = cleanAndSortTree({ children: tree })
 
-  return cleanedTree ? cleanedTree.children : null
+  return cleanedTree ? cleanedTree.children : []
 }
 
 /** Sorts a map by an indexPathString property. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,44 +40,42 @@ importers:
     specifiers:
       '@types/node': ^18.7.6
       '@types/react': ^18.0.17
-      jotai: ^1.7.8
       motion: ^10.14.0
       next: ^12.2.5
       next-transpile-modules: ^9.0.0
       react: '*'
       react-dom: '*'
       reforest: workspace:*
-      suspend-react: ^0.0.8
-      tree-visit: ^0.1.2
       typescript: ^4.7.4
+      valtio: ^1.6.3
     dependencies:
       '@types/node': 18.7.6
       '@types/react': 18.0.17
-      jotai: 1.7.8_react@18.2.0
       motion: 10.14.0
       next: 12.2.5_biqbaboplfbrettd7655fr4n2y
       next-transpile-modules: 9.0.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       reforest: link:../reforest
-      suspend-react: 0.0.8_react@18.2.0
-      tree-visit: 0.1.2
       typescript: 4.7.4
+      valtio: 1.6.3_react@18.2.0
 
   packages/reforest:
     specifiers:
       '@jsxui/layout': ^0.1.3
-      jotai: ^1.7.8
       performant-array-to-tree: ^1.11.0
+      proxy-memoize: ^1.2.0
       react: '*'
       react-dom: '*'
       suspend-react: ^0.0.8
       tsup: ^6.2.2
       typescript: '*'
+      valtio: ^1.6.3
     dependencies:
-      jotai: 1.7.8_react@18.2.0
       performant-array-to-tree: 1.11.0
+      proxy-memoize: 1.2.0
       suspend-react: 0.0.8_react@18.2.0
+      valtio: 1.6.3_react@18.2.0
     devDependencies:
       '@jsxui/layout': 0.1.3
       react: 18.2.0
@@ -2843,43 +2841,6 @@ packages:
       - ts-node
     dev: true
 
-  /jotai/1.7.8_react@18.2.0:
-    resolution: {integrity: sha512-rXwWz6uLqyZUCRzWIPiYTjI1hjskVxVpDN3lBoOHi66z6uQFkFmKwR8YhcQd+Ex4lODlReuKNIx6WwsF9aKy3g==}
-    engines: {node: '>=12.7.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      '@babel/template': '*'
-      '@tanstack/query-core': '*'
-      '@urql/core': '*'
-      immer: '*'
-      optics-ts: '*'
-      react: '>=16.8'
-      valtio: '*'
-      wonka: '*'
-      xstate: '*'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      '@babel/template':
-        optional: true
-      '@tanstack/query-core':
-        optional: true
-      '@urql/core':
-        optional: true
-      immer:
-        optional: true
-      optics-ts:
-        optional: true
-      valtio:
-        optional: true
-      wonka:
-        optional: true
-      xstate:
-        optional: true
-    dependencies:
-      react: 18.2.0
-    dev: false
-
   /joycon/3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -3361,6 +3322,20 @@ packages:
       sisteransi: 1.0.5
     dev: true
 
+  /proxy-compare/2.2.0:
+    resolution: {integrity: sha512-hEtMJevUmOByZCTw1NRUVaWWHCGJLO0ogizpey8yX6zMPolDe8YVa+PHgMOTiZuyUkFj+hMKs/1UaM0+ZkuvgA==}
+    dev: false
+
+  /proxy-compare/2.3.0:
+    resolution: {integrity: sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ==}
+    dev: false
+
+  /proxy-memoize/1.2.0:
+    resolution: {integrity: sha512-0heYEZb4yMfhdduz8T+BPJOCKGukc81WRJaYF0k6ZsJz/NkPLhGFqe6OLdiZURr5kC1byps5wdqLN6DC2tYAFw==}
+    dependencies:
+      proxy-compare: 2.3.0
+    dev: false
+
   /psl/1.9.0:
     resolution: {integrity: sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==}
     dev: true
@@ -3767,6 +3742,7 @@ packages:
 
   /tree-visit/0.1.2:
     resolution: {integrity: sha512-uyeYL92ZHERjB28jTlV1swfGj9BfxF0tJunlJ4eHRtWFyWyLWC7/FOs6/HLDDITHIbTQlhU0qWiePYtCc9zczA==}
+    dev: true
 
   /ts-interface-checker/0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -3999,6 +3975,35 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.8.0
     dev: true
+
+  /valtio/1.6.3_react@18.2.0:
+    resolution: {integrity: sha512-ySg2q5nFFSY0zSm/a/sxEGHshWGGvelo4m4y/oAlO92fuXZ9WHSi0J214P3ZDjDiveGp08wck0qJZcA2ubEj+Q==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@babel/helper-module-imports': '>=7.12'
+      '@babel/types': '>=7.13'
+      aslemammad-vite-plugin-macro: '>=1.0.0-alpha.1'
+      babel-plugin-macros: '>=3.0'
+      react: '>=16.8'
+      vite: '>=2.8.6'
+    peerDependenciesMeta:
+      '@babel/helper-module-imports':
+        optional: true
+      '@babel/types':
+        optional: true
+      aslemammad-vite-plugin-macro:
+        optional: true
+      babel-plugin-macros:
+        optional: true
+      react:
+        optional: true
+      vite:
+        optional: true
+    dependencies:
+      proxy-compare: 2.2.0
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
+    dev: false
 
   /w3c-hr-time/1.0.2:
     resolution: {integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==}


### PR DESCRIPTION
This rewrites the state layer to use Valtio again 🫠. Jotai was causing flickering when computing tree state no matter what method was used. Thankfully, Valtio does not suffer from this problem. Using the learnings from the Jotai rewrite everything has been merged back into one solution with two new `useTreeEffect` and `useTreeSnapshot` hooks.